### PR TITLE
refactor: Introduce enum like class for node types

### DIFF
--- a/src/Nodes/NodeType.php
+++ b/src/Nodes/NodeType.php
@@ -1,0 +1,181 @@
+<?php
+
+namespace SVG\Nodes;
+
+use SVG\Nodes\Embedded\SVGForeignObject;
+use SVG\Nodes\Embedded\SVGImage;
+use SVG\Nodes\Filters\SVGFEBlend;
+use SVG\Nodes\Filters\SVGFEColorMatrix;
+use SVG\Nodes\Filters\SVGFEComponentTransfer;
+use SVG\Nodes\Filters\SVGFEComposite;
+use SVG\Nodes\Filters\SVGFEConvolveMatrix;
+use SVG\Nodes\Filters\SVGFEDiffuseLighting;
+use SVG\Nodes\Filters\SVGFEDisplacementMap;
+use SVG\Nodes\Filters\SVGFEDistantLight;
+use SVG\Nodes\Filters\SVGFEDropShadow;
+use SVG\Nodes\Filters\SVGFEFlood;
+use SVG\Nodes\Filters\SVGFEFuncA;
+use SVG\Nodes\Filters\SVGFEFuncB;
+use SVG\Nodes\Filters\SVGFEFuncG;
+use SVG\Nodes\Filters\SVGFEFuncR;
+use SVG\Nodes\Filters\SVGFEGaussianBlur;
+use SVG\Nodes\Filters\SVGFEImage;
+use SVG\Nodes\Filters\SVGFEMerge;
+use SVG\Nodes\Filters\SVGFEMergeNode;
+use SVG\Nodes\Filters\SVGFEMorphology;
+use SVG\Nodes\Filters\SVGFEOffset;
+use SVG\Nodes\Filters\SVGFEPointLight;
+use SVG\Nodes\Filters\SVGFESpecularLighting;
+use SVG\Nodes\Filters\SVGFESpotLight;
+use SVG\Nodes\Filters\SVGFETile;
+use SVG\Nodes\Filters\SVGFETurbulence;
+use SVG\Nodes\Filters\SVGFilter;
+use SVG\Nodes\Presentation\SVGAnimate;
+use SVG\Nodes\Presentation\SVGAnimateMotion;
+use SVG\Nodes\Presentation\SVGAnimateTransform;
+use SVG\Nodes\Presentation\SVGLinearGradient;
+use SVG\Nodes\Presentation\SVGMPath;
+use SVG\Nodes\Presentation\SVGRadialGradient;
+use SVG\Nodes\Presentation\SVGSet;
+use SVG\Nodes\Presentation\SVGStop;
+use SVG\Nodes\Presentation\SVGView;
+use SVG\Nodes\Shapes\SVGCircle;
+use SVG\Nodes\Shapes\SVGEllipse;
+use SVG\Nodes\Shapes\SVGLine;
+use SVG\Nodes\Shapes\SVGPath;
+use SVG\Nodes\Shapes\SVGPolygon;
+use SVG\Nodes\Shapes\SVGPolyline;
+use SVG\Nodes\Shapes\SVGRect;
+use SVG\Nodes\Structures\SVGClipPath;
+use SVG\Nodes\Structures\SVGDefs;
+use SVG\Nodes\Structures\SVGDocumentFragment;
+use SVG\Nodes\Structures\SVGGroup;
+use SVG\Nodes\Structures\SVGLinkGroup;
+use SVG\Nodes\Structures\SVGMarker;
+use SVG\Nodes\Structures\SVGMask;
+use SVG\Nodes\Structures\SVGMetadata;
+use SVG\Nodes\Structures\SVGPattern;
+use SVG\Nodes\Structures\SVGScript;
+use SVG\Nodes\Structures\SVGStyle;
+use SVG\Nodes\Structures\SVGSwitch;
+use SVG\Nodes\Structures\SVGSymbol;
+use SVG\Nodes\Structures\SVGUse;
+use SVG\Nodes\Texts\SVGDesc;
+use SVG\Nodes\Texts\SVGText;
+use SVG\Nodes\Texts\SVGTextPath;
+use SVG\Nodes\Texts\SVGTitle;
+use SVG\Nodes\Texts\SVGTSpan;
+use ValueError;
+
+/**
+ * A list of all known SVG node types and their respective classes.
+ */
+abstract class NodeType
+{
+    /**
+     * @var string[] $nodeTypes Map of tag names to fully-qualified class names.
+     */
+    private const NODE_TYPES = [
+        'foreignObject' => SVGForeignObject::class,
+        'image' => SVGImage::class,
+
+        'feBlend' => SVGFEBlend::class,
+        'feColorMatrix' => SVGFEColorMatrix::class,
+        'feComponentTransfer' => SVGFEComponentTransfer::class,
+        'feComposite' => SVGFEComposite::class,
+        'feConvolveMatrix' => SVGFEConvolveMatrix::class,
+        'feDiffuseLighting' => SVGFEDiffuseLighting::class,
+        'feDisplacementMap' => SVGFEDisplacementMap::class,
+        'feDistantLight' => SVGFEDistantLight::class,
+        'feDropShadow' => SVGFEDropShadow::class,
+        'feFlood' => SVGFEFlood::class,
+        'feFuncA' => SVGFEFuncA::class,
+        'feFuncB' => SVGFEFuncB::class,
+        'feFuncG' => SVGFEFuncG::class,
+        'feFuncR' => SVGFEFuncR::class,
+        'feGaussianBlur' => SVGFEGaussianBlur::class,
+        'feImage' => SVGFEImage::class,
+        'feMerge' => SVGFEMerge::class,
+        'feMergeNode' => SVGFEMergeNode::class,
+        'feMorphology' => SVGFEMorphology::class,
+        'feOffset' => SVGFEOffset::class,
+        'fePointLight' => SVGFEPointLight::class,
+        'feSpecularLighting' => SVGFESpecularLighting::class,
+        'feSpotLight' => SVGFESpotLight::class,
+        'feTile' => SVGFETile::class,
+        'feTurbulence' => SVGFETurbulence::class,
+        'filter' => SVGFilter::class,
+
+        'animate' => SVGAnimate::class,
+        'animateMotion' => SVGAnimateMotion::class,
+        'animateTransform' => SVGAnimateTransform::class,
+        'linearGradient' => SVGLinearGradient::class,
+        'mpath' => SVGMPath::class,
+        'radialGradient' => SVGRadialGradient::class,
+        'set' => SVGSet::class,
+        'stop' => SVGStop::class,
+        'view' => SVGView::class,
+
+        'circle' => SVGCircle::class,
+        'ellipse' => SVGEllipse::class,
+        'line' => SVGLine::class,
+        'path' => SVGPath::class,
+        'polygon' => SVGPolygon::class,
+        'polyline' => SVGPolyline::class,
+        'rect' => SVGRect::class,
+
+        'clipPath' => SVGClipPath::class,
+        'defs' => SVGDefs::class,
+        'svg' => SVGDocumentFragment::class,
+        'g' => SVGGroup::class,
+        'a' => SVGLinkGroup::class,
+        'marker' => SVGMarker::class,
+        'mask' => SVGMask::class,
+        'metadata' => SVGMetadata::class,
+        'pattern' => SVGPattern::class,
+        'script' => SVGScript::class,
+        'style' => SVGStyle::class,
+        'switch' => SVGSwitch::class,
+        'symbol' => SVGSymbol::class,
+        'use' => SVGUse::class,
+
+        'desc' => SVGDesc::class,
+        'text' => SVGText::class,
+        'textPath' => SVGTextPath::class,
+        'title' => SVGTitle::class,
+        'tspan' => SVGTSpan::class,
+    ];
+
+    /**
+     * @return string[] List of node types, with tags/node type as key, class FQDN as value.
+     */
+    public static function cases(): array
+    {
+        return self::NODE_TYPES;
+    }
+
+    /**
+     * Find a nodes class FQDN based on the node tag name ('svg', 'rect', 'title', etc.).
+     *
+     * @param string $type
+     * @return string|null The class FQDN or null if unknown.
+     */
+    public static function tryFrom(string $type): ?string
+    {
+        try {
+            return self::from($type);
+        } catch (ValueError $e) {
+            return null;
+        }
+    }
+
+    public static function from(string $type)
+    {
+        if (isset(self::NODE_TYPES[$type])) {
+            return self::NODE_TYPES[$type];
+        }
+
+        $error = sprintf('"%s" is not a valid backing value for enum "NodeType"', $type);
+        throw new ValueError($error);
+    }
+}

--- a/src/Reading/NodeRegistry.php
+++ b/src/Reading/NodeRegistry.php
@@ -2,152 +2,15 @@
 
 namespace SVG\Reading;
 
-use SVG\Nodes\Embedded\SVGForeignObject;
-use SVG\Nodes\Embedded\SVGImage;
-use SVG\Nodes\Filters\SVGFEBlend;
-use SVG\Nodes\Filters\SVGFEColorMatrix;
-use SVG\Nodes\Filters\SVGFEComponentTransfer;
-use SVG\Nodes\Filters\SVGFEComposite;
-use SVG\Nodes\Filters\SVGFEConvolveMatrix;
-use SVG\Nodes\Filters\SVGFEDiffuseLighting;
-use SVG\Nodes\Filters\SVGFEDisplacementMap;
-use SVG\Nodes\Filters\SVGFEDistantLight;
-use SVG\Nodes\Filters\SVGFEDropShadow;
-use SVG\Nodes\Filters\SVGFEFlood;
-use SVG\Nodes\Filters\SVGFEFuncA;
-use SVG\Nodes\Filters\SVGFEFuncB;
-use SVG\Nodes\Filters\SVGFEFuncG;
-use SVG\Nodes\Filters\SVGFEFuncR;
-use SVG\Nodes\Filters\SVGFEGaussianBlur;
-use SVG\Nodes\Filters\SVGFEImage;
-use SVG\Nodes\Filters\SVGFEMerge;
-use SVG\Nodes\Filters\SVGFEMergeNode;
-use SVG\Nodes\Filters\SVGFEMorphology;
-use SVG\Nodes\Filters\SVGFEOffset;
-use SVG\Nodes\Filters\SVGFEPointLight;
-use SVG\Nodes\Filters\SVGFESpecularLighting;
-use SVG\Nodes\Filters\SVGFESpotLight;
-use SVG\Nodes\Filters\SVGFETile;
-use SVG\Nodes\Filters\SVGFETurbulence;
-use SVG\Nodes\Filters\SVGFilter;
-use SVG\Nodes\Presentation\SVGAnimate;
-use SVG\Nodes\Presentation\SVGAnimateMotion;
-use SVG\Nodes\Presentation\SVGAnimateTransform;
-use SVG\Nodes\Presentation\SVGLinearGradient;
-use SVG\Nodes\Presentation\SVGMPath;
-use SVG\Nodes\Presentation\SVGRadialGradient;
-use SVG\Nodes\Presentation\SVGSet;
-use SVG\Nodes\Presentation\SVGStop;
-use SVG\Nodes\Presentation\SVGView;
-use SVG\Nodes\Shapes\SVGCircle;
-use SVG\Nodes\Shapes\SVGEllipse;
-use SVG\Nodes\Shapes\SVGLine;
-use SVG\Nodes\Shapes\SVGPath;
-use SVG\Nodes\Shapes\SVGPolygon;
-use SVG\Nodes\Shapes\SVGPolyline;
-use SVG\Nodes\Shapes\SVGRect;
-use SVG\Nodes\Structures\SVGClipPath;
-use SVG\Nodes\Structures\SVGDefs;
-use SVG\Nodes\Structures\SVGDocumentFragment;
-use SVG\Nodes\Structures\SVGGroup;
-use SVG\Nodes\Structures\SVGLinkGroup;
-use SVG\Nodes\Structures\SVGMarker;
-use SVG\Nodes\Structures\SVGMask;
-use SVG\Nodes\Structures\SVGMetadata;
-use SVG\Nodes\Structures\SVGPattern;
-use SVG\Nodes\Structures\SVGScript;
-use SVG\Nodes\Structures\SVGStyle;
-use SVG\Nodes\Structures\SVGSwitch;
-use SVG\Nodes\Structures\SVGSymbol;
-use SVG\Nodes\Structures\SVGUse;
+use SVG\Nodes\NodeType;
 use SVG\Nodes\SVGNode;
 use SVG\Nodes\SVGGenericNodeType;
-use SVG\Nodes\Texts\SVGDesc;
-use SVG\Nodes\Texts\SVGText;
-use SVG\Nodes\Texts\SVGTextPath;
-use SVG\Nodes\Texts\SVGTitle;
-use SVG\Nodes\Texts\SVGTSpan;
 
 /**
- * This class contains a list of all known SVG node types, and enables dynamic
- * instantiation of the respective class.
+ * This class enables dynamic instantiation of all known SVG node types.
  */
 class NodeRegistry
 {
-    /**
-    * @var string[] $nodeTypes Map of tag names to fully-qualified class names.
-    */
-    private static $nodeTypes = [
-        'foreignObject'         => SVGForeignObject::class,
-        'image'                 => SVGImage::class,
-
-        'feBlend'               => SVGFEBlend::class,
-        'feColorMatrix'         => SVGFEColorMatrix::class,
-        'feComponentTransfer'   => SVGFEComponentTransfer::class,
-        'feComposite'           => SVGFEComposite::class,
-        'feConvolveMatrix'      => SVGFEConvolveMatrix::class,
-        'feDiffuseLighting'     => SVGFEDiffuseLighting::class,
-        'feDisplacementMap'     => SVGFEDisplacementMap::class,
-        'feDistantLight'        => SVGFEDistantLight::class,
-        'feDropShadow'          => SVGFEDropShadow::class,
-        'feFlood'               => SVGFEFlood::class,
-        'feFuncA'               => SVGFEFuncA::class,
-        'feFuncB'               => SVGFEFuncB::class,
-        'feFuncG'               => SVGFEFuncG::class,
-        'feFuncR'               => SVGFEFuncR::class,
-        'feGaussianBlur'        => SVGFEGaussianBlur::class,
-        'feImage'               => SVGFEImage::class,
-        'feMerge'               => SVGFEMerge::class,
-        'feMergeNode'           => SVGFEMergeNode::class,
-        'feMorphology'          => SVGFEMorphology::class,
-        'feOffset'              => SVGFEOffset::class,
-        'fePointLight'          => SVGFEPointLight::class,
-        'feSpecularLighting'    => SVGFESpecularLighting::class,
-        'feSpotLight'           => SVGFESpotLight::class,
-        'feTile'                => SVGFETile::class,
-        'feTurbulence'          => SVGFETurbulence::class,
-        'filter'                => SVGFilter::class,
-
-        'animate'               => SVGAnimate::class,
-        'animateMotion'         => SVGAnimateMotion::class,
-        'animateTransform'      => SVGAnimateTransform::class,
-        'linearGradient'        => SVGLinearGradient::class,
-        'mpath'                 => SVGMPath::class,
-        'radialGradient'        => SVGRadialGradient::class,
-        'set'                   => SVGSet::class,
-        'stop'                  => SVGStop::class,
-        'view'                  => SVGView::class,
-
-        'circle'                => SVGCircle::class,
-        'ellipse'               => SVGEllipse::class,
-        'line'                  => SVGLine::class,
-        'path'                  => SVGPath::class,
-        'polygon'               => SVGPolygon::class,
-        'polyline'              => SVGPolyline::class,
-        'rect'                  => SVGRect::class,
-
-        'clipPath'              => SVGClipPath::class,
-        'defs'                  => SVGDefs::class,
-        'svg'                   => SVGDocumentFragment::class,
-        'g'                     => SVGGroup::class,
-        'a'                     => SVGLinkGroup::class,
-        'marker'                => SVGMarker::class,
-        'mask'                  => SVGMask::class,
-        'metadata'              => SVGMetadata::class,
-        'pattern'               => SVGPattern::class,
-        'script'                => SVGScript::class,
-        'style'                 => SVGStyle::class,
-        'switch'                => SVGSwitch::class,
-        'symbol'                => SVGSymbol::class,
-        'use'                   => SVGUse::class,
-
-        'desc'                  => SVGDesc::class,
-        'text'                  => SVGText::class,
-        'textPath'              => SVGTextPath::class,
-        'title'                 => SVGTitle::class,
-        'tspan'                 => SVGTSpan::class,
-    ];
-
     /**
      * Instantiate a node class matching the given type.
      * If no such class exists, a generic one will be used.
@@ -158,8 +21,7 @@ class NodeRegistry
      */
     public static function create(string $type): SVGNode
     {
-        if (isset(self::$nodeTypes[$type])) {
-            $nodeClass = self::$nodeTypes[$type];
+        if (($nodeClass = NodeType::tryFrom($type)) !== null) {
             return new $nodeClass();
         }
 

--- a/tests/Nodes/NodeTypeTest.php
+++ b/tests/Nodes/NodeTypeTest.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace SVG\Nodes;
+
+use PHPUnit\Framework\TestCase;
+use SVG\Nodes\Shapes\SVGRect;
+use ValueError;
+
+class NodeTypeTest extends TestCase
+{
+    public function testCases()
+    {
+        $this->assertIsArray(NodeType::cases());
+    }
+
+    /** @dataProvider provideTryFrom */
+    public function testTryFrom($expectedResult, string $type)
+    {
+        $result = NodeType::tryFrom($type);
+        $this->assertSame($expectedResult, $result);
+    }
+
+    /** @provides testTryFrom */
+    public function provideTryFrom()
+    {
+        return [
+            "It returns correct NodeType FQDN for rect" => [SVGRect::class, 'rect'],
+            "It returns 'null' if NodeType is unknown" => [null, 'foobar']
+        ];
+    }
+
+    public function testFromReturnsNodeFQDN()
+    {
+        $result = NodeType::from('rect');
+        $this->assertSame(SVGRect::class, $result);
+    }
+
+    public function testFromThrowsError()
+    {
+        $this->expectException(ValueError::class);
+        NodeType::from('FooBar');
+    }
+}

--- a/tests/Reading/NodeRegistryTest.php
+++ b/tests/Reading/NodeRegistryTest.php
@@ -2,7 +2,7 @@
 
 namespace SVG\Reading;
 
-use ReflectionProperty;
+use SVG\Nodes\NodeType;
 use SVG\Nodes\Shapes\SVGRect;
 use SVG\Nodes\SVGGenericNodeType;
 use SVG\Nodes\SVGNode;
@@ -21,20 +21,16 @@ class NodeRegistryTest extends \PHPUnit\Framework\TestCase
     }
 
     /** @dataProvider provideItConstructsAllKnownTypes */
-    public function testItConstructsAllKnownTypes($type,$expectedResult)
+    public function testItConstructsAllKnownTypes($type, $expectedResult)
     {
         $result = NodeRegistry::create($type);
         $this->assertInstanceOf($expectedResult, $result);
         $this->assertInstanceOf(SVGNode::class, $result);
     }
 
-    public function provideItConstructsAllKnownTypes()
+    public function provideItConstructsAllKnownTypes(): \Generator
     {
-        $reflectedProperty = new ReflectionProperty(NodeRegistry::class, 'nodeTypes');
-        $reflectedProperty->setAccessible(true);
-        $types = $reflectedProperty->getValue();
-
-        foreach ($types as $type => $class) {
+        foreach (NodeType::cases() as $type => $class) {
             yield "\$type='$type'" => [$type, $class];
         }
     }

--- a/tests/Reading/NodeRegistryTest.php
+++ b/tests/Reading/NodeRegistryTest.php
@@ -2,8 +2,10 @@
 
 namespace SVG\Reading;
 
+use ReflectionProperty;
 use SVG\Nodes\Shapes\SVGRect;
 use SVG\Nodes\SVGGenericNodeType;
+use SVG\Nodes\SVGNode;
 
 /**
  * @covers \SVG\Reading\NodeRegistry
@@ -16,6 +18,25 @@ class NodeRegistryTest extends \PHPUnit\Framework\TestCase
     {
         $result = NodeRegistry::create('rect');
         $this->assertInstanceOf(SVGRect::class, $result);
+    }
+
+    /** @dataProvider provideItConstructsAllKnownTypes */
+    public function testItConstructsAllKnownTypes($type,$expectedResult)
+    {
+        $result = NodeRegistry::create($type);
+        $this->assertInstanceOf($expectedResult, $result);
+        $this->assertInstanceOf(SVGNode::class, $result);
+    }
+
+    public function provideItConstructsAllKnownTypes()
+    {
+        $reflectedProperty = new ReflectionProperty(NodeRegistry::class, 'nodeTypes');
+        $reflectedProperty->setAccessible(true);
+        $types = $reflectedProperty->getValue();
+
+        foreach ($types as $type => $class) {
+            yield "\$type='$type'" => [$type, $class];
+        }
     }
 
     public function testShouldUseGenericTypeForOthers()


### PR DESCRIPTION
In future versions (if support for <8.1 is ever dropped) this enum like class may be replaced with a proper enum. Then it could potentially replace several more strings (tag names) across the repo.