### PR TITLE
CI: PHPUnit convert deprecations to errors

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit bootstrap="vendor/autoload.php" colors="true">
+<phpunit bootstrap="vendor/autoload.php" colors="true" convertDeprecationsToExceptions="true">
     <testsuites>
         <testsuite name="Test Suite for meyfa/php-svg">
             <directory suffix="Test.php">tests</directory>
@@ -10,4 +10,7 @@
             <directory suffix=".php">src</directory>
         </include>
     </coverage>
+    <php>
+        <ini name="error_reporting" value="E_ALL"/>
+    </php>
 </phpunit>


### PR DESCRIPTION
Changes PHPUnit config to:
- Enable error reporting
- Error on deprecation warnings

Note that due to PHPUnits way of parsing warnings, not all deprecations may lead to errors.